### PR TITLE
3x3-equation-solver 1.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "3x3-equation-solver",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Solves systems of 3 equations with three unknowns.",
   "main": "lib/index.js",
   "directories": {


### PR DESCRIPTION
Make the module backwards compatible with <4.0.0 versions of Node.js.
