### PR TITLE
3x3-equation-solver 1.2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 
-# 3x3-equation-solver [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![Version](https://img.shields.io/npm/v/3x3-equation-solver.svg)](https://www.npmjs.com/package/3x3-equation-solver) [![Downloads](https://img.shields.io/npm/dt/3x3-equation-solver.svg)](https://www.npmjs.com/package/3x3-equation-solver) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
+# 3x3-equation-solver
+
+ [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![AMA](https://img.shields.io/badge/ask%20me-anything-1abc9c.svg)](https://github.com/IonicaBizau/ama) [![Version](https://img.shields.io/npm/v/3x3-equation-solver.svg)](https://www.npmjs.com/package/3x3-equation-solver) [![Downloads](https://img.shields.io/npm/dt/3x3-equation-solver.svg)](https://www.npmjs.com/package/3x3-equation-solver) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
 
 > Solves systems of 3 equations with three unknowns.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "3x3-equation-solver",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Solves systems of 3 equations with three unknowns.",
   "main": "lib/index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "src/",
     "resources/",
     "menu/",
+    "scripts/",
     "cli.js",
     "index.js"
   ]


### PR DESCRIPTION
- Updated the README.md following the new template. :memo:
  - Use [`babel-it`](https://github.com/IonicaBizau/babel-it) to babelify the code, so the module is now compatible with older versions of Node.js.
