### PR TITLE
3x3-equation-solver 1.2.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "3x3-equation-solver",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Solves systems of 3 equations with three unknowns.",
   "main": "lib/index.js",
   "directories": {


### PR DESCRIPTION
- Updated the README.md following the new template. :memo:
- Use [`babel-it`](https://github.com/IonicaBizau/babel-it) to babelify the code, so the module is now compatible with older versions of Node.js.
